### PR TITLE
added EvmProgram based on evmlab Program

### DIFF
--- a/evmdasm/__init__.py
+++ b/evmdasm/__init__.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # Author : <github.com/tintinweb>
 from .instructions import Instruction
-from .disassembler import EvmBytecode, EvmInstructions, EvmDisassembler
+from .disassembler import EvmBytecode, EvmInstructions, EvmDisassembler, EvmProgram
 
 
-__ALL__ = ["Instruction", "EvbBytecode", "EvmInstructions", "EvmDisassembler"]
+__ALL__ = ["Instruction", "EvbBytecode", "EvmInstructions", "EvmDisassembler", "EvmProgram"]

--- a/evmdasm/disassembler.py
+++ b/evmdasm/disassembler.py
@@ -199,3 +199,6 @@ class EvmProgram(object):
         instr = self._registry.create_instruction("PUSH%d" % len(data))
         instr.operand_bytes = data
         return instr
+
+    def assemble(self):
+        return self._program.assemble()

--- a/evmdasm/disassembler.py
+++ b/evmdasm/disassembler.py
@@ -139,6 +139,10 @@ class EvmInstructions(list):
         self._update_instruction_addresses(at_index=self._fix_addresses_at_index)
         return super().pop(*args, **kwargs)
 
+    def index(self, *args, **kwargs):
+        self._update_instruction_addresses(at_index=self._fix_addresses_at_index)
+        return super().index(*args, **kwargs)
+
     def __delitem__(self, i):
         self._fix_addresses_required = True
         self._fix_addresses_at_index = min(self._fix_addresses_at_index,

--- a/evmdasm/disassembler.py
+++ b/evmdasm/disassembler.py
@@ -182,7 +182,9 @@ class EvmProgram(object):
 
         def callback(*args, **kwargs):
             new_instr = instr.clone()
-            for arg in new_instr.args:
+            assert(not kwargs)  # we do not yet support kwargs
+            assert(len(args) == new_instr.args)
+            for arg in args:
                 self._program.append(self.create_push_for_data(arg))
             self._program.append(new_instr)
 

--- a/evmdasm/disassembler.py
+++ b/evmdasm/disassembler.py
@@ -165,7 +165,10 @@ class EvmProgram(object):
     p = EvmProgram()
     p.push("abcdefg")
     c.call(arg1, arg2, arg3, ...)
-    c.op("PUSH")
+    c.op("JUMPDEST")
+
+    # allow chaining
+    c.op("OR").op("OR")
 
     """
 
@@ -183,15 +186,17 @@ class EvmProgram(object):
         def callback(*args, **kwargs):
             new_instr = instr.clone()
             assert(not kwargs)  # we do not yet support kwargs
-            assert(len(args) == new_instr.args)
+            assert(len(args) <= new_instr.args)
             for arg in args:
                 self._program.append(self.create_push_for_data(arg))
             self._program.append(new_instr)
+            return self
 
         return callback
 
     def op(self, name):
         self._program.append(self._registry.create_instruction(name.upper()))
+        return self
 
     def create_push_for_data(self, data):
         # expect bytes but silently convert int2bytes

--- a/evmdasm/instruction_registry.py
+++ b/evmdasm/instruction_registry.py
@@ -54,6 +54,9 @@ class InstructionRegistry(object):
                                            category="unknown")
         else:
             raise Exception("name or opcode required")
+
+        if not instr:
+            raise TypeError("Failed to create instruction. Invalid Name/Opcode or Operand size")
         return instr.clone()
 
     @property

--- a/evmdasm/utils.py
+++ b/evmdasm/utils.py
@@ -33,3 +33,8 @@ def is_hexstring(s):
     hex_digits = set(string.hexdigits)
     # if s is long, then it is faster to check against a set
     return all(c in hex_digits for c in s)
+
+def int2bytes(i):
+    hex_string = '%x' % i
+    n = len(hex_string)
+    return binascii.unhexlify(hex_string.zfill(n + (n & 1)))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-version = "0.1.7"
+version = "0.1.8"
 name = "evmdasm"
 
 setup(

--- a/tests/test_disassembler.py
+++ b/tests/test_disassembler.py
@@ -3,9 +3,49 @@
 # Author : <github.com/tintinweb>
 
 import unittest
+import random
 
 from evmdasm import EvmDisassembler, EvmBytecode, EvmInstructions, Instruction, registry
 import evmdasm.utils as utils
+
+
+class EvmInstructionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.testcode = '606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806319e30bc7146100775780635bd74afe146101055780639df211541461017f578063b1d131bf146101ad575b6000366001919061007492919061042d565b50005b341561008257600080fd5b61008a610202565b6040518080602001828103825283818151815260200191508051906020019080838360005b838110156100ca5780820151818401526020810190506100af565b50505050905090810190601f1680156100f75780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b61017d600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919080359060200190919050506102a0565b005b6101ab600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190505061038d565b005b34156101b857600080fd5b6101c0610408565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b60018054600181600116156101000203166002900480601f0160208091040260200160405190810160405280929190818152602001828054600181600116156101000203166002900480156102985780601f1061026d57610100808354040283529160200191610298565b820191906000526020600020905b81548152906001019060200180831161027b57829003601f168201915b505050505081565b3373ffffffffffffffffffffffffffffffffffffffff166000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff161415156102fb57600080fd5b8273ffffffffffffffffffffffffffffffffffffffff16818360405180828051906020019080838360005b83811015610341578082015181840152602081019050610326565b50505050905090810190601f16801561036e5780820380516001836020036101000a031916815260200191505b5091505060006040518083038185876187965a03f19250505050505050565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166108fc3073ffffffffffffffffffffffffffffffffffffffff16319081150290604051600060405180830381858888f19350505050151561040557600080fd5b50565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b828054600181600116156101000203166002900490600052602060002090601f016020900481019282601f1061046e57803560ff191683800117855561049c565b8280016001018555821561049c579182015b8281111561049b578235825591602001919060010190610480565b5b5090506104a991906104ad565b5090565b6104cf91905b808211156104cb5760008160009055506001016104b3565b5090565b905600a165627a7a723058202592c848fd2bdbf19b6558815a8c0a67519b4ad552eb001c92109a188ef215950029'
+        self.evmcode = EvmBytecode("0x%s" % self.testcode)
+
+
+    def _check_address_linear(self, instructions):
+        pc = instructions[0].address
+        for instr in instructions:
+            self.assertEqual(instr.address, pc)
+            pc += len(instr)
+
+    def test_address_linear(self):
+        self._check_address_linear(self.evmcode.disassemble())
+
+    def test_append(self):
+        instructions = self.evmcode.disassemble()
+        for _ in range(4000):
+            instructions.append(registry.create_instruction(name="JUMPDEST"))
+            self._check_address_linear(instructions)
+
+    def test_insert(self):
+        instructions = self.evmcode.disassemble()
+
+        instructions.insert(0, registry.create_instruction(name="JUMPDEST"))
+        self._check_address_linear(instructions)
+
+        for idx in range(len(instructions)):
+            instructions.insert(-idx, registry.create_instruction(name="JUMPDEST"))
+            self._check_address_linear(instructions)
+
+        for _ in range(len(instructions)):
+            idx = random.randint(0, len(instructions)-1)
+            instructions.insert(idx, registry.create_instruction(name="JUMPDEST"))
+            self._check_address_linear(instructions)
+
 
 
 class EvmBytecodeTest(unittest.TestCase):
@@ -93,7 +133,7 @@ class MyInstruction(Instruction):
 
 
 
-class EvmDisassemblerTest(unittest.TestCase):
+class EvmDisassemblerCustomTest(unittest.TestCase):
 
     def setUp(self):
         self.registry = registry.InstructionRegistry(instructions=registry.INSTRUCTIONS, _template_cls=MyInstruction)

--- a/tests/test_evmprogram.py
+++ b/tests/test_evmprogram.py
@@ -1,0 +1,64 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author : <github.com/tintinweb>
+
+import unittest
+import random
+
+from evmdasm import EvmInstructions, EvmProgram, registry, Instruction
+
+
+
+class EvmInstructionTest(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_assemble(self):
+        p = EvmProgram()
+        p.push(1)
+        p.push(0x0101)
+        p.op("JUMPDEST")
+        p.push(0xc0fefe)
+
+        assembled = p.assemble()
+
+        self.assertEqual(assembled.as_hexstring, "60016101015b62c0fefe")
+
+        expect = [("PUSH1","01"),
+                  ("PUSH2","0101"),
+                  ("JUMPDEST",""),
+                  ("PUSH3","c0fefe")]
+
+        for idx,instr in enumerate(p.assemble().disassemble()):
+            self.assertEqual(instr.name, expect[idx][0])
+            self.assertEqual(instr.operand, expect[idx][1])
+
+    def test_assemble(self):
+        p = EvmProgram()
+        p.push(1)
+        p.push(0x0101)
+        p.op("JUMPDEST")
+        p.push(0xc0fefe)
+        #T.Gas("gas"), T.Address("address"), T.CallValue("value"), T.MemOffset("inOffset"), T.Length("inSize"), T.MemOffset("retOffset"), T.Length("retSize")
+        p.call(1,2,3,4,5,6,7)
+
+        assembled = p.assemble()
+        self.assertEqual(assembled.as_hexstring, "60016101015b62c0fefe6001600260036004600560066007f1")
+
+        self.assertEqual(assembled.disassemble().as_string.strip(), """PUSH1 01
+PUSH2 0101
+JUMPDEST 
+PUSH3 c0fefe
+PUSH1 01
+PUSH1 02
+PUSH1 03
+PUSH1 04
+PUSH1 05
+PUSH1 06
+PUSH1 07
+CALL""".strip())
+
+
+
+

--- a/tests/test_instruction.py
+++ b/tests/test_instruction.py
@@ -41,4 +41,3 @@ class InstructionTest(unittest.TestCase):
         self.assertEqual(push.operand_bytes, value)
         self.assertEqual(push.operand_length, len(value))
 
-


### PR DESCRIPTION
* allows adding opcodes directly via `EvmProgram.op(<name>)`
* or functional as `EvmProgram.<name>(<optional_args, ...>)`

```python

p = EvmProgram()
p.push(12345)
p.create2(arg1,arg2,arg3,...)
p.op("JUMPDEST")

p.op("OR").op("OR").shr().add(1,2)

bytecode = p.assemble().as_hexstring  #(or as_bytes)

```

[see wiki](https://github.com/tintinweb/evmdasm/wiki/evmdasm-assembler)
